### PR TITLE
Style markdown links purple for better visual distinction

### DIFF
--- a/src/app/_components/markdown-styles.module.css
+++ b/src/app/_components/markdown-styles.module.css
@@ -16,3 +16,7 @@
 .markdown h3 {
   @apply text-2xl mt-8 mb-4 leading-snug;
 }
+
+.markdown a {
+  @apply text-purple-600 underline hover:text-purple-800 dark:text-purple-400 dark:hover:text-purple-300 transition-colors;
+}


### PR DESCRIPTION
Add purple color styling to anchor tags within blog post content.
Uses purple-600 (light mode) and purple-400 (dark mode) with
underline and hover state transitions.

https://claude.ai/code/session_014aiiSVaxq3UuPFRLajc1XA