### PR TITLE
Add giscus comments to blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@giscus/react": "^3.1.0",
         "classnames": "^2.5.1",
         "date-fns": "^3.6.0",
         "feed": "^4.2.2",
@@ -47,6 +48,18 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -481,6 +494,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.7.tgz",
@@ -733,6 +761,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1433,6 +1467,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -1730,6 +1773,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@giscus/react": "^3.1.0",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "feed": "^4.2.2",

--- a/src/app/_components/comments.tsx
+++ b/src/app/_components/comments.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Giscus from "@giscus/react";
+import { useEffect, useState } from "react";
+
+// TODO: Replace these placeholder values with your actual giscus configuration.
+// 1. Enable Discussions on your repo: https://github.com/jccurrie1/blog/settings
+// 2. Install the giscus app: https://github.com/apps/giscus
+// 3. Go to https://giscus.app, enter "jccurrie1/blog", pick the "Announcements"
+//    category, and copy the data-category and data-category-id values below.
+const GISCUS_REPO = "jccurrie1/blog" as const;
+const GISCUS_REPO_ID = "R_kgDOOVFoDA";
+const GISCUS_CATEGORY = "Announcements";
+const GISCUS_CATEGORY_ID = "REPLACE_ME";
+
+export function Comments() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const isDark =
+        document.documentElement.classList.contains("dark");
+      setTheme(isDark ? "dark" : "light");
+    };
+
+    updateTheme();
+
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto mt-16">
+      <Giscus
+        repo={GISCUS_REPO}
+        repoId={GISCUS_REPO_ID}
+        category={GISCUS_CATEGORY}
+        categoryId={GISCUS_CATEGORY_ID}
+        mapping="pathname"
+        reactionsEnabled="1"
+        emitMetadata="0"
+        inputPosition="top"
+        theme={theme}
+        lang="en"
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/src/app/_components/comments.tsx
+++ b/src/app/_components/comments.tsx
@@ -3,15 +3,10 @@
 import Giscus from "@giscus/react";
 import { useEffect, useState } from "react";
 
-// TODO: Replace these placeholder values with your actual giscus configuration.
-// 1. Enable Discussions on your repo: https://github.com/jccurrie1/blog/settings
-// 2. Install the giscus app: https://github.com/apps/giscus
-// 3. Go to https://giscus.app, enter "jccurrie1/blog", pick the "Announcements"
-//    category, and copy the data-category and data-category-id values below.
 const GISCUS_REPO = "jccurrie1/blog" as const;
 const GISCUS_REPO_ID = "R_kgDOOVFoDA";
 const GISCUS_CATEGORY = "Announcements";
-const GISCUS_CATEGORY_ID = "REPLACE_ME";
+const GISCUS_CATEGORY_ID = "DIC_kwDOOVFoDM4C3Fld";
 
 export function Comments() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -44,7 +39,8 @@ export function Comments() {
         mapping="pathname"
         reactionsEnabled="1"
         emitMetadata="0"
-        inputPosition="top"
+        strict="0"
+        inputPosition="bottom"
         theme={theme}
         lang="en"
         loading="lazy"

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -8,6 +8,7 @@ import Container from "@/app/_components/container";
 import Header from "@/app/_components/header";
 import { PostBody } from "@/app/_components/post-body";
 import { PostHeader } from "@/app/_components/post-header";
+import { Comments } from "@/app/_components/comments";
 
 export default async function Post(props: Params) {
   const params = await props.params;
@@ -32,6 +33,7 @@ export default async function Post(props: Params) {
             author={post.author}
           />
           <PostBody content={content} />
+          <Comments />
         </article>
       </Container>
     </main>


### PR DESCRIPTION
Integrate GitHub Discussions-backed commenting via giscus on every post page.
Includes dark mode sync via MutationObserver on the html class attribute.
Category ID still needs to be configured after enabling Discussions on the repo.

https://claude.ai/code/session_01B4gbtiEtwz9jdibruS1EWG